### PR TITLE
Implementação para Uso de Imports em Outras IDE

### DIFF
--- a/simulator/memory.py
+++ b/simulator/memory.py
@@ -4,7 +4,8 @@ import os
 
 class Mem:
     def __init__(self):
-        self.data = os.path.join('../DATA', 'mem.json')
+        current_dir = os.path.dirname(os.path.abspath(__file__))
+        self.data = os.path.join(current_dir, 'DATA', 'mem.json')
         if os.path.exists(self.data):
             self.load_process_queue()
         else:

--- a/simulator/src/disassemble.py
+++ b/simulator/src/disassemble.py
@@ -1,7 +1,13 @@
+import sys
+import os
 import dis
 import re
 
-from simulator.Memory import Mem
+# Adiciona o diretório onde memory.py está localizado ao sys.path
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+sys.path.append(project_root)
+
+from simulator.memory import Mem
 
 
 def disassemble(code):


### PR DESCRIPTION
No caso mudei como acha o caminho do arquivo mem.json no memory.py e como disassemble.py acha memory.py, isso foi necessario para que minha IDE (vscode, que inclusive outros membros usam) consigam executar o código.